### PR TITLE
ci: drop AWS_* env from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,9 +45,6 @@ jobs:
           environment: |
             BOT_TOKEN=${{ secrets.BOT_TOKEN }}
             OWNER_ID=${{ secrets.OWNER_ID }}
-            AWS_ACCESS_KEY_ID=${{ secrets.YC_S3_ACCESS_KEY_ID }}
-            AWS_SECRET_ACCESS_KEY=${{ secrets.YC_S3_SECRET_ACCESS_KEY }}
-            AWS_REGION=ru-central1
           include: |
             dist/**
             package.json


### PR DESCRIPTION
## Summary
- Initial deploy of #7 failed: `INVALID_ARGUMENT: Illegal value of environment variable with key [AWS_ACCESS_KEY_ID]` because the GitHub secrets `YC_S3_ACCESS_KEY_ID`/`YC_S3_SECRET_ACCESS_KEY` are not set, so the action passed empty strings.
- Verified against current prod via YC API: `$latest` version of `duty-group-bot` runs with `service_account_id: ajerdikcv0fdb1s370uf` and only `BOT_TOKEN`/`OWNER_ID` in env. S3 access works through that runtime SA via the YC metadata service — no static keys needed.
- Removed `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` from deploy.yml. `@aws-sdk/client-s3` defaultProvider will pick up creds from `169.254.169.254` (YC emulates the EC2 metadata endpoint).

## Test plan
- [ ] Merge → re-run deploy.yml via workflow_dispatch on master.
- [ ] Confirm new version is created in YC (`$latest` advances).
- [ ] Send `/help` in Telegram bot → response contains the new `functionVersion`.
- [ ] Send `/list` (or `/duty`) → S3 read works without credential errors.