### PR TITLE
ci: provide static S3 credentials via env

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,9 @@ jobs:
           environment: |
             BOT_TOKEN=${{ secrets.BOT_TOKEN }}
             OWNER_ID=${{ secrets.OWNER_ID }}
+            AWS_ACCESS_KEY_ID=${{ secrets.YC_S3_ACCESS_KEY_ID }}
+            AWS_SECRET_ACCESS_KEY=${{ secrets.YC_S3_SECRET_ACCESS_KEY }}
+            AWS_REGION=ru-central1
           include: |
             dist/**
             package.json


### PR DESCRIPTION
## Summary

Fix `CredentialsProviderError: Could not load credentials from any providers` observed in prod after the TS migration deploy.

Verified facts:
- `@aws-sdk/client-s3` (v3) `defaultProvider` cannot pick up creds in YC Cloud Functions — YC does **not** auto-populate `AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY` from the linked SA, and YC metadata service (`169.254.169.254`) returns Google-style payloads, not AWS-compatible IAM-role data.
- Runtime SA `ajerdikcv0fdb1s370uf` already has `READ`+`WRITE` on bucket `duty-group-bot-storage` (bucket ACL confirmed), so permissions are not the problem.

What this PR does:
- Re-adds `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_REGION` to `deploy.yml` so SDK v3 can authenticate.
- New static access key for runtime SA was created via `yc iam access-key create` and stored in repo secrets `YC_S3_ACCESS_KEY_ID` / `YC_S3_SECRET_ACCESS_KEY` (legacy 2020 key on the same SA is left untouched — it's used elsewhere).

## Test plan
- [ ] Merge → re-run deploy.yml on master.
- [ ] `/list` or `/duty` in the bot → should now succeed without `Ошибка при запросе списка дежурных` from `CredentialsProviderError`.
- [ ] Logs (`yc serverless function logs duty-group-bot --since 10m`) show no credential errors.