### PR TITLE
feat(service): self-heal missing properties, drop countPeople, default dutyCount=1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
+        "@smithy/util-stream": "^4.5.25",
         "@types/node": "^22.0.0",
+        "aws-sdk-client-mock": "^4.1.0",
         "esbuild": "^0.24.0",
         "eslint": "^9.0.0",
         "globals": "^15.0.0",
@@ -1936,6 +1938,47 @@
         "win32"
       ]
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
@@ -2685,6 +2728,23 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
@@ -3165,6 +3225,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3350,6 +3422,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -3873,6 +3955,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3990,6 +4079,29 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -4116,6 +4228,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -4309,6 +4432,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4490,6 +4632,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@smithy/util-stream": "^4.5.25",
     "@types/node": "^22.0.0",
+    "aws-sdk-client-mock": "^4.1.0",
     "esbuild": "^0.24.0",
     "eslint": "^9.0.0",
     "globals": "^15.0.0",

--- a/src/service.ts
+++ b/src/service.ts
@@ -17,7 +17,7 @@ const TRIGGER_FOLDER_NAME = 'trigger';
 const BUCKET_NAME = 'duty-group-bot-storage';
 
 const INIT_TRIGGER = { time: 9 };
-const INIT_PROPERTIES: Properties = { dutyCount: 2, countPeople: 0, lastDuty: [] };
+const INIT_PROPERTIES: Properties = { dutyCount: 1, lastDuty: [] };
 
 export class Service {
     constructor(private readonly s3: S3Client) {}
@@ -149,8 +149,8 @@ export class Service {
         } catch (e) {
             throw new ServiceError(`Ошибка при регистрации пользователя @${username}.`, e);
         }
-        const properties = await this._incrementUser(chat);
-        return `@${username} добавлен в дежурные.\nКоличество дежурных: ${properties.countPeople}`;
+        const count = (await this.list(chat)).length;
+        return `@${username} добавлен в дежурные.\nКоличество дежурных: ${count}`;
     }
 
     async unreg(chat: DomainChat, username: string): Promise<string> {
@@ -166,8 +166,8 @@ export class Service {
         } catch (e) {
             throw new ServiceError(`Ошибка при удалении пользователя ${username}.`, e);
         }
-        const properties = await this._decrementUser(chat);
-        return `@${username} удалён из дежурных.\nКоличество дежурных: ${properties.countPeople}`;
+        const count = (await this.list(chat)).length;
+        return `@${username} удалён из дежурных.\nКоличество дежурных: ${count}`;
     }
 
     async duty(chat: DomainChat): Promise<string[]> {
@@ -258,6 +258,7 @@ export class Service {
             const response = await this.s3.send(new GetObjectCommand({ Bucket: BUCKET_NAME, Key: key }));
             return await readJson<Properties>(response.Body);
         } catch (e) {
+            if (isNotFound(e)) return { ...INIT_PROPERTIES };
             if (e instanceof ServiceError) throw e;
             throw new ServiceError(`Ошибка при получении настроек для чата ${key}.`, e);
         }
@@ -277,16 +278,6 @@ export class Service {
         return newProperties;
     }
 
-    private async _incrementUser(chat: DomainChat): Promise<Properties> {
-        const properties = await this._getProperties(chat);
-        return this._updateProperties(chat, { ...properties, countPeople: properties.countPeople + 1 });
-    }
-
-    private async _decrementUser(chat: DomainChat): Promise<Properties> {
-        const properties = await this._getProperties(chat);
-        if (properties.countPeople <= 0) return properties;
-        return this._updateProperties(chat, { ...properties, countPeople: properties.countPeople - 1 });
-    }
 }
 
 function isNotFound(e: unknown): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ export interface DomainChat {
 
 export interface Properties {
     dutyCount: number;
-    countPeople: number;
     lastDuty: string[];
 }
 

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -1,0 +1,233 @@
+import { Readable } from 'node:stream';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { sdkStreamMixin } from '@smithy/util-stream';
+import {
+    S3Client,
+    HeadObjectCommand,
+    GetObjectCommand,
+    PutObjectCommand,
+    DeleteObjectCommand,
+    ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+
+import { Service } from '../src/service';
+import type { DomainChat, Properties } from '../src/types';
+
+const BUCKET = 'duty-group-bot-storage';
+const chat: DomainChat = { id: -100123, type: 'group', title: 'TestChat' };
+const propertiesKey = `${chat.type}/${chat.id}/properties.json`;
+const chatPrefix = `${chat.type}/${chat.id}/`;
+
+function jsonBody(obj: unknown) {
+    const stream = new Readable();
+    stream.push(JSON.stringify(obj));
+    stream.push(null);
+    return sdkStreamMixin(stream);
+}
+
+function notFound() {
+    const e = new Error('Not found');
+    e.name = 'NoSuchKey';
+    (e as unknown as { $metadata: { httpStatusCode: number } }).$metadata = { httpStatusCode: 404 };
+    return e;
+}
+
+const s3Mock = mockClient(S3Client);
+
+beforeEach(() => {
+    s3Mock.reset();
+});
+
+function makeService() {
+    return new Service(new S3Client({}));
+}
+
+describe('Service.reg — chat WITHOUT properties.json (self-heal)', () => {
+    it('creates user key and reports count derived from list, not from missing properties', async () => {
+        // Arrange: properties.json is missing; user does not exist; after PutObject the chat has 1 user.
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@alice` }).rejects(notFound());
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@alice` }).resolves({});
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [{ Key: `${chatPrefix}@alice` }],
+        });
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({});
+
+        const service = makeService();
+
+        // Act
+        const result = await service.reg(chat, 'alice');
+
+        // Assert: no exception, count comes from real list (1), not from a stale counter (0).
+        expect(result).toContain('@alice');
+        expect(result).toContain('Количество дежурных: 1');
+    });
+});
+
+describe('Service.reg — chat WITH properties.json', () => {
+    it('appends user and reports count = existing users + 1', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@bob` }).rejects(notFound());
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@bob` }).resolves({});
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}properties.json` },
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+            ],
+        });
+
+        const service = makeService();
+        const result = await service.reg(chat, 'bob');
+
+        expect(result).toContain('@bob');
+        expect(result).toContain('Количество дежурных: 2'); // 2 user-keys, properties.json is filtered
+    });
+
+    it('returns "уже добавлен" without PutObject when user exists', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@alice` }).resolves({});
+
+        const service = makeService();
+        const result = await service.reg(chat, 'alice');
+
+        expect(result).toBe('Пользователь @alice уже добавлен.');
+        expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+    });
+});
+
+describe('Service.unreg — chat WITHOUT properties.json (self-heal)', () => {
+    it('removes user key and reports count from list', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@alice` }).resolves({});
+        s3Mock.on(DeleteObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@alice` }).resolves({});
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [], // nobody left
+        });
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({});
+
+        const service = makeService();
+        const result = await service.unreg(chat, 'alice');
+
+        expect(result).toContain('@alice');
+        expect(result).toContain('Количество дежурных: 0');
+    });
+
+    it('returns "уже удалён" without DeleteObject when user does not exist', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: `${chatPrefix}@ghost` }).rejects(notFound());
+
+        const service = makeService();
+        const result = await service.unreg(chat, 'ghost');
+
+        expect(result).toBe('Пользователь @ghost уже удалён.');
+        expect(s3Mock.commandCalls(DeleteObjectCommand)).toHaveLength(0);
+    });
+});
+
+describe('Service.duty — chat WITHOUT properties.json (self-heal + new dutyCount default)', () => {
+    it('does not throw, picks 1 person (new default), and persists properties.json', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+                { Key: `${chatPrefix}@carol` },
+            ],
+        });
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+
+        const writes: Properties[] = [];
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).callsFake((input) => {
+            writes.push(JSON.parse(input.Body as string));
+            return {};
+        });
+
+        const service = makeService();
+        const duty = await service.duty(chat);
+
+        expect(duty).toHaveLength(1);
+        expect(['@alice', '@bob', '@carol']).toContain(duty[0]);
+
+        // properties.json got written with new dutyCount default
+        expect(writes).toHaveLength(1);
+        expect(writes[0]?.dutyCount).toBe(1);
+        expect(writes[0]?.lastDuty).toEqual(duty);
+    });
+});
+
+describe('Service.setDutyCount — chat WITHOUT properties.json (self-heal)', () => {
+    it('persists properties with the new dutyCount and does not throw', async () => {
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+
+        let written: Properties | undefined;
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).callsFake((input) => {
+            written = JSON.parse(input.Body as string);
+            return {};
+        });
+
+        const service = makeService();
+        const result = await service.setDutyCount(chat, 3);
+
+        expect(result).toBe(3);
+        expect(written?.dutyCount).toBe(3);
+    });
+});
+
+describe('Service.init — defaults', () => {
+    it('uses dutyCount=1 by default', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+
+        let written: Properties | undefined;
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).callsFake((input) => {
+            written = JSON.parse(input.Body as string);
+            return {};
+        });
+
+        const service = makeService();
+        await service.init(chat);
+
+        expect(written?.dutyCount).toBe(1);
+        expect(written?.lastDuty).toEqual([]);
+    });
+});
+
+describe('Service._getProperties via duty — non-404 errors still bubble up', () => {
+    it('raises ServiceError when GetObject fails with a non-404 error (e.g. permission denied)', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [{ Key: `${chatPrefix}@alice` }],
+        });
+        const denied = new Error('AccessDenied');
+        denied.name = 'AccessDenied';
+        (denied as unknown as { $metadata: { httpStatusCode: number } }).$metadata = { httpStatusCode: 403 };
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(denied);
+
+        const service = makeService();
+        await expect(service.duty(chat)).rejects.toThrow(/настроек/);
+    });
+});
+
+describe('Service.duty — happy path with existing properties.json', () => {
+    it('reads dutyCount from existing properties and avoids re-picking the same people in a round', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+                { Key: `${chatPrefix}@carol` },
+                { Key: `${chatPrefix}properties.json` },
+            ],
+        });
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({
+            Body: jsonBody({ dutyCount: 2, lastDuty: ['@alice'] }),
+        });
+        const writes: Properties[] = [];
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).callsFake((input) => {
+            writes.push(JSON.parse(input.Body as string));
+            return {};
+        });
+
+        const service = makeService();
+        const duty = await service.duty(chat);
+
+        expect(duty).toHaveLength(2);
+        expect(duty).not.toContain('@alice'); // alice was in lastDuty, must be excluded
+        expect(writes[0]?.dutyCount).toBe(2);
+    });
+});


### PR DESCRIPTION
## Why

After the TS migration deploy, a bucket walk found 8 group chats with `@user` keys but no `properties.json` — likely from `/add`/`/reg` called before `/start`. Subsequent `/duty` crashes with `Ошибка при получении настроек для чата ...` from `_getProperties` 404.

While fixing this, the `countPeople` field stood out as duplicate state — it copies what `ListObjectsV2` already gives us. Worse, naive self-heal of `properties.json` would create an off-by-one against `countPeople` (since `reg` does `PutObject(user)` *before* `_incrementUser`). Removing the counter eliminates the class of bugs entirely.

## Changes

- **`_getProperties` self-heal:** if `GetObject properties.json` returns 404, return `{...INIT_PROPERTIES}` defaults. Non-404 errors (e.g. `AccessDenied`) still throw `ServiceError`. The file materialises on the next `_updateProperties` (called by `setDutyCount`/`duty`).
- **Drop `countPeople`:** removed from `Properties`, `INIT_PROPERTIES`, `reg`, `unreg`. Removed `_incrementUser` / `_decrementUser`. `reg`/`unreg` now derive count from `(await this.list(chat)).length` — single source of truth.
- **`dutyCount` default 2 → 1.**
- **`CLAUDE.md`** updated (S3 layout + conventions).

## Tests (TDD)

10 new `Service` tests via `aws-sdk-client-mock` + `@smithy/util-stream`. Wrote them red first, then implemented:

- `reg`/`unreg`/`duty`/`setDutyCount` on a chat **without** `properties.json` — must self-heal, not throw.
- `reg`/`unreg` on a chat **with** `properties.json` — count comes from `list().length`, idempotent on repeat.
- `init` writes `dutyCount: 1` by default.
- `_getProperties` non-404 errors (e.g. `AccessDenied 403`) still bubble as `ServiceError`.
- `duty` happy-path with existing `lastDuty` — excludes already-served users.

`npm test` → 14/14 green (4 handler smoke + 10 service). `npm run check`, `npm run lint`, `npm run build` all green.

## Verification plan
- [ ] Merge → re-run `deploy.yml` on master.
- [ ] In one of the 8 broken group chats: `/duty` should now succeed (creates `properties.json` with `dutyCount: 1` on the fly, picks 1 person).
- [ ] `/list`, `/reg`, `/unreg` in any chat — count line shows the actual list size.
- [ ] Logs (`yc serverless function logs`) — no `Ошибка при получении настроек` between subsequent calls in the same broken chat.