### PR TITLE
test: expand coverage to service edge cases, utils, and controller

### DIFF
--- a/tests/controller.test.ts
+++ b/tests/controller.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { Controller, formatError } from '../src/controller';
+import { ServiceError } from '../src/errors';
+import type { Service } from '../src/service';
+import type { DomainChat } from '../src/types';
+
+const TOKEN = '123:fake';
+const OWNER_ID = '999';
+
+interface SendCall {
+    chatId: number | string;
+    text: string;
+}
+
+function makeController(serviceOverrides: Partial<Service> = {}): {
+    controller: Controller;
+    service: Partial<Service>;
+    sentMessages: SendCall[];
+} {
+    const sentMessages: SendCall[] = [];
+    const service = {
+        getChats: vi.fn(async () => [] as DomainChat[]),
+        duty: vi.fn(async () => [] as string[]),
+        ...serviceOverrides,
+    } as Partial<Service>;
+
+    const controller = new Controller(service as Service, TOKEN, OWNER_ID, { functionVersion: 'test' });
+
+    // Stub out the network: we want to capture sent messages, not hit Telegram.
+    const bot = controller.getBot();
+    bot.telegram.sendMessage = (async (chatId: number | string, text: string) => {
+        sentMessages.push({ chatId, text });
+        return { message_id: sentMessages.length };
+    }) as unknown as typeof bot.telegram.sendMessage;
+
+    return { controller, service, sentMessages };
+}
+
+describe('formatError', () => {
+    it('returns "<no error>" for null/undefined', () => {
+        expect(formatError(undefined)).toBe('<no error>');
+        expect(formatError(null)).toBe('<no error>');
+    });
+
+    it('formats Error with name, message, and stack', () => {
+        const err = new Error('boom');
+        const out = formatError(err);
+        expect(out).toContain('Error');
+        expect(out).toContain('boom');
+    });
+
+    it('returns string input as-is', () => {
+        expect(formatError('something failed')).toBe('something failed');
+    });
+
+    it('JSON-stringifies plain objects', () => {
+        expect(formatError({ a: 1, b: 'x' })).toBe('{"a":1,"b":"x"}');
+    });
+
+    it('falls back to String() on circular structures (JSON.stringify throws)', () => {
+        const obj: Record<string, unknown> = { name: 'circ' };
+        obj.self = obj;
+        const out = formatError(obj);
+        // Either way, it must not throw and must produce *something* string-ish.
+        expect(typeof out).toBe('string');
+        expect(out.length).toBeGreaterThan(0);
+    });
+
+    it('formats ServiceError with cause via .stack/.message of the outer error (cause not unwrapped)', () => {
+        const err = new ServiceError('outer', new Error('inner'));
+        const out = formatError(err);
+        expect(out).toContain('ServiceError');
+        expect(out).toContain('outer');
+    });
+});
+
+describe('Controller.pt — pluralizer', () => {
+    const { controller } = makeController();
+
+    it('returns single form for 1 item', () => {
+        expect(controller.pt(['a'], 'plural', 'single')).toBe('single');
+    });
+
+    it('returns plural form for >1 items', () => {
+        expect(controller.pt(['a', 'b'], 'plural', 'single')).toBe('plural');
+    });
+
+    it('returns single form for empty / undefined', () => {
+        expect(controller.pt([], 'plural', 'single')).toBe('single');
+        expect(controller.pt(undefined, 'plural', 'single')).toBe('single');
+    });
+});
+
+describe('Controller.trigger', () => {
+    it('returns early without sending anything when getChats returns no chats', async () => {
+        const { controller, service, sentMessages } = makeController();
+
+        await controller.trigger();
+
+        expect(service.getChats).toHaveBeenCalledOnce();
+        expect(service.duty).not.toHaveBeenCalled();
+        expect(sentMessages).toHaveLength(0);
+    });
+
+    it('sends "Дежурный на сегодня" with single duty for each chat', async () => {
+        const chats: DomainChat[] = [
+            { id: -100, type: 'group' },
+            { id: -200, type: 'supergroup' },
+        ];
+        const dutyByChat = new Map<DomainChat['id'], string[]>([
+            [-100, ['@alice']],
+            [-200, ['@bob', '@carol']],
+        ]);
+        const { controller, sentMessages } = makeController({
+            getChats: vi.fn(async () => chats),
+            duty: vi.fn(async (chat: DomainChat) => dutyByChat.get(chat.id) ?? []),
+        });
+
+        await controller.trigger();
+
+        expect(sentMessages).toHaveLength(2);
+        const byId = new Map(sentMessages.map((m) => [m.chatId, m.text]));
+
+        expect(byId.get(-100)).toBe('Дежурный на сегодня: @alice');
+        // For >1 duty, the join uses '\n', so the listing goes on new lines.
+        expect(byId.get(-200)).toBe('Дежурные на сегодня: \n@bob\n@carol');
+    });
+
+    it('sends fallback "Дежурных нет" when service.duty returns []', async () => {
+        const chats: DomainChat[] = [{ id: -100, type: 'group' }];
+        const { controller, sentMessages } = makeController({
+            getChats: vi.fn(async () => chats),
+            duty: vi.fn(async () => []),
+        });
+
+        await controller.trigger();
+
+        expect(sentMessages).toHaveLength(1);
+        expect(sentMessages[0]?.text).toBe('Дежурных нет. Добавьте людей в список.');
+    });
+
+    it('notifies owner and skips chat-level send when getChats throws', async () => {
+        const { controller, sentMessages } = makeController({
+            getChats: vi.fn(async () => {
+                throw new Error('list-failed');
+            }),
+        });
+
+        await controller.trigger();
+
+        // Only the owner notification is sent, no chat sends.
+        expect(sentMessages).toHaveLength(1);
+        expect(sentMessages[0]?.chatId).toBe(OWNER_ID);
+        expect(sentMessages[0]?.text).toContain('обработке тригера');
+    });
+
+    it('isolates per-chat failures: notifies owner for the bad one, still delivers to the good one', async () => {
+        const chats: DomainChat[] = [
+            { id: -100, type: 'group' },
+            { id: -200, type: 'group' },
+        ];
+        const { controller, sentMessages } = makeController({
+            getChats: vi.fn(async () => chats),
+            duty: vi.fn(async (chat: DomainChat) => {
+                if (chat.id === -100) throw new Error('duty-failed');
+                return ['@bob'];
+            }),
+        });
+
+        await controller.trigger();
+
+        // Owner gets one error notification + chat -200 gets its delivery.
+        const ownerMsgs = sentMessages.filter((m) => m.chatId === OWNER_ID);
+        const chatMsgs = sentMessages.filter((m) => m.chatId !== OWNER_ID);
+
+        expect(ownerMsgs).toHaveLength(1);
+        expect(ownerMsgs[0]?.text).toContain('рассылке тригера для чата -100');
+
+        expect(chatMsgs).toHaveLength(1);
+        expect(chatMsgs[0]?.chatId).toBe(-200);
+        expect(chatMsgs[0]?.text).toBe('Дежурный на сегодня: @bob');
+    });
+});

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -8,6 +8,7 @@ import {
     GetObjectCommand,
     PutObjectCommand,
     DeleteObjectCommand,
+    DeleteObjectsCommand,
     ListObjectsV2Command,
 } from '@aws-sdk/client-s3';
 
@@ -229,5 +230,282 @@ describe('Service.duty — happy path with existing properties.json', () => {
         expect(duty).toHaveLength(2);
         expect(duty).not.toContain('@alice'); // alice was in lastDuty, must be excluded
         expect(writes[0]?.dutyCount).toBe(2);
+    });
+});
+
+describe('Service.duty — round complete (lastDuty equals dutyUsers)', () => {
+    it('returns lastDuty as-is and does NOT write properties.json', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+            ],
+        });
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({
+            Body: jsonBody({ dutyCount: 2, lastDuty: ['@bob', '@alice'] }),
+        });
+
+        const service = makeService();
+        const duty = await service.duty(chat);
+
+        expect(new Set(duty)).toEqual(new Set(['@alice', '@bob']));
+        // No PutObject for properties.json — round is complete, lastDuty stays as is.
+        expect(s3Mock.commandCalls(PutObjectCommand, { Key: propertiesKey })).toHaveLength(0);
+    });
+});
+
+describe('Service.duty — dutyCount > available users', () => {
+    it('truncates to the number of available (non-lastDuty) users without throwing', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+            ],
+        });
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({
+            Body: jsonBody({ dutyCount: 10, lastDuty: ['@alice'] }),
+        });
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({});
+
+        const service = makeService();
+        const duty = await service.duty(chat);
+
+        expect(duty).toEqual(['@bob']);
+    });
+});
+
+describe('Service.duty — empty user list', () => {
+    it('returns [] and writes empty lastDuty', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [{ Key: `${chatPrefix}properties.json` }],
+        });
+        s3Mock.on(GetObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({
+            Body: jsonBody({ dutyCount: 1, lastDuty: ['@stale'] }),
+        });
+        const writes: Properties[] = [];
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).callsFake((input) => {
+            writes.push(JSON.parse(input.Body as string));
+            return {};
+        });
+
+        const service = makeService();
+        const duty = await service.duty(chat);
+
+        expect(duty).toEqual([]);
+        expect(writes[0]?.lastDuty).toEqual([]);
+    });
+});
+
+describe('Service.getChats — parsing of trigger keys', () => {
+    it('parses numeric and string ids, skips malformed entries', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: 'trigger/' }).resolves({
+            Contents: [
+                { Key: 'trigger/group@-100123' },        // numeric id
+                { Key: 'trigger/supergroup@abc-xyz' },   // non-numeric id stays string
+                { Key: 'trigger/private@77' },
+                { Key: 'trigger/no-separator' },         // malformed — no @
+                { Key: 'trigger/' },                     // empty tail
+                {},                                       // missing Key entirely
+            ],
+        });
+
+        const service = makeService();
+        const chats = await service.getChats();
+
+        expect(chats).toEqual([
+            { id: -100123, type: 'group' },
+            { id: 'abc-xyz', type: 'supergroup' },
+            { id: 77, type: 'private' },
+        ]);
+    });
+
+    it('returns [] when bucket has no triggers', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: 'trigger/' }).resolves({});
+
+        const service = makeService();
+        await expect(service.getChats()).resolves.toEqual([]);
+    });
+
+    it('wraps S3 errors in ServiceError', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: 'trigger/' }).rejects(new Error('boom'));
+
+        const service = makeService();
+        await expect(service.getChats()).rejects.toThrow(/тригеров/);
+    });
+});
+
+describe('Service.triggerOn / triggerOff', () => {
+    const triggerKey = `trigger/${chat.type}@${chat.id}`;
+
+    it('triggerOn writes trigger key with default time=9', async () => {
+        let written: { time?: number } | undefined;
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: triggerKey }).callsFake((input) => {
+            written = JSON.parse(input.Body as string);
+            return {};
+        });
+
+        const service = makeService();
+        const msg = await service.triggerOn(chat);
+
+        expect(written?.time).toBe(9);
+        expect(msg).toContain('создан');
+    });
+
+    it('triggerOn wraps S3 errors in ServiceError', async () => {
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: triggerKey }).rejects(new Error('boom'));
+
+        const service = makeService();
+        await expect(service.triggerOn(chat)).rejects.toThrow(/триггера/);
+    });
+
+    it('triggerOff deletes the trigger key', async () => {
+        s3Mock.on(DeleteObjectCommand, { Bucket: BUCKET, Key: triggerKey }).resolves({});
+
+        const service = makeService();
+        const msg = await service.triggerOff(chat);
+
+        expect(msg).toContain('удалён');
+        expect(s3Mock.commandCalls(DeleteObjectCommand, { Key: triggerKey })).toHaveLength(1);
+    });
+
+    it('triggerOff wraps S3 errors in ServiceError', async () => {
+        s3Mock.on(DeleteObjectCommand, { Bucket: BUCKET, Key: triggerKey }).rejects(new Error('boom'));
+
+        const service = makeService();
+        await expect(service.triggerOff(chat)).rejects.toThrow(/удалении триггера/);
+    });
+});
+
+describe('Service.init — already exists / error', () => {
+    it('returns "уже создано" when properties.json exists and does NOT write it', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).resolves({});
+
+        const service = makeService();
+        const result = await service.init(chat);
+
+        expect(result).toContain('уже создано');
+        expect(s3Mock.commandCalls(PutObjectCommand, { Key: propertiesKey })).toHaveLength(0);
+    });
+
+    it('wraps PutObject failure in ServiceError', async () => {
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(new Error('boom'));
+
+        const service = makeService();
+        await expect(service.init(chat)).rejects.toThrow(/создании хранилища/);
+    });
+
+    it('wraps non-404 HeadObject failure in ServiceError', async () => {
+        const denied = new Error('denied');
+        denied.name = 'AccessDenied';
+        (denied as unknown as { $metadata: { httpStatusCode: number } }).$metadata = { httpStatusCode: 403 };
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(denied);
+
+        const service = makeService();
+        await expect(service.init(chat)).rejects.toThrow(/проверке хранилища/);
+    });
+});
+
+describe('Service.clear', () => {
+    it('deletes user keys + properties.json and tolerates triggerOff failure', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+                { Key: `${chatPrefix}properties.json` },
+            ],
+        });
+        let deletedKeys: string[] = [];
+        s3Mock.on(DeleteObjectsCommand, { Bucket: BUCKET }).callsFake((input) => {
+            deletedKeys = (input.Delete?.Objects ?? []).map((o: { Key?: string }) => o.Key ?? '');
+            return {};
+        });
+        // triggerOff is best-effort: even if it fails, clear() must not throw.
+        s3Mock.on(DeleteObjectCommand).rejects(new Error('trigger-off failed'));
+
+        const service = makeService();
+        await expect(service.clear(chat)).resolves.toBeUndefined();
+
+        expect(deletedKeys.sort()).toEqual([
+            `${chatPrefix}@alice`,
+            `${chatPrefix}@bob`,
+            `${chatPrefix}properties.json`,
+        ].sort());
+    });
+
+    it('still issues a DeleteObjects (with just properties.json) when no users registered', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({ Contents: [] });
+        const calls: string[][] = [];
+        s3Mock.on(DeleteObjectsCommand, { Bucket: BUCKET }).callsFake((input) => {
+            calls.push((input.Delete?.Objects ?? []).map((o: { Key?: string }) => o.Key ?? ''));
+            return {};
+        });
+        s3Mock.on(DeleteObjectCommand).resolves({});
+
+        const service = makeService();
+        await service.clear(chat);
+
+        // Always at least properties.json is queued for deletion.
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toEqual([`${chatPrefix}properties.json`]);
+    });
+
+    it('wraps DeleteObjects failure in ServiceError', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [{ Key: `${chatPrefix}@alice` }],
+        });
+        s3Mock.on(DeleteObjectsCommand, { Bucket: BUCKET }).rejects(new Error('boom'));
+
+        const service = makeService();
+        await expect(service.clear(chat)).rejects.toThrow(/очистке хранилища/);
+    });
+});
+
+describe('Service.reset', () => {
+    it('clears the chat and re-initialises properties.json', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [{ Key: `${chatPrefix}@alice` }],
+        });
+        s3Mock.on(DeleteObjectsCommand, { Bucket: BUCKET }).resolves({});
+        s3Mock.on(DeleteObjectCommand).resolves({});
+        s3Mock.on(HeadObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).rejects(notFound());
+
+        let initBody: Properties | undefined;
+        s3Mock.on(PutObjectCommand, { Bucket: BUCKET, Key: propertiesKey }).callsFake((input) => {
+            initBody = JSON.parse(input.Body as string);
+            return {};
+        });
+
+        const service = makeService();
+        const msg = await service.reset(chat);
+
+        expect(msg).toContain('создано');
+        expect(initBody).toEqual({ dutyCount: 1, lastDuty: [] });
+    });
+});
+
+describe('Service.list', () => {
+    it('filters out properties.json and returns only user keys', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).resolves({
+            Contents: [
+                { Key: `${chatPrefix}properties.json` },
+                { Key: `${chatPrefix}@alice` },
+                { Key: `${chatPrefix}@bob` },
+                { Key: chatPrefix }, // empty name (the prefix itself) — must be skipped
+                {},                  // missing Key
+            ],
+        });
+
+        const service = makeService();
+        const users = await service.list(chat);
+
+        expect(users.sort()).toEqual(['@alice', '@bob']);
+    });
+
+    it('wraps S3 failure in ServiceError', async () => {
+        s3Mock.on(ListObjectsV2Command, { Bucket: BUCKET, Prefix: chatPrefix }).rejects(new Error('boom'));
+
+        const service = makeService();
+        await expect(service.list(chat)).rejects.toThrow(/списка дежурных/);
     });
 });

--- a/tests/util/command.test.ts
+++ b/tests/util/command.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+import { parseCommandArgs, stripAt } from '../../src/util/command';
+
+describe('parseCommandArgs', () => {
+    it('returns [] for undefined', () => {
+        expect(parseCommandArgs(undefined)).toEqual([]);
+    });
+
+    it('returns [] for empty / whitespace-only string', () => {
+        expect(parseCommandArgs('')).toEqual([]);
+        expect(parseCommandArgs('   ')).toEqual([]);
+    });
+
+    it('strips the leading command token', () => {
+        expect(parseCommandArgs('/add')).toEqual([]);
+        expect(parseCommandArgs('/add @alice')).toEqual(['@alice']);
+        expect(parseCommandArgs('/add @alice @bob')).toEqual(['@alice', '@bob']);
+    });
+
+    it('collapses arbitrary whitespace between args', () => {
+        expect(parseCommandArgs('/add   @alice\t@bob   @carol')).toEqual(['@alice', '@bob', '@carol']);
+    });
+
+    it('handles bot mention in command (e.g. /add@DutyBot)', () => {
+        // The first token is dropped wholesale, regardless of @suffix.
+        expect(parseCommandArgs('/add@DutyBot @alice')).toEqual(['@alice']);
+    });
+});
+
+describe('stripAt', () => {
+    it('removes a single leading @', () => {
+        expect(stripAt('@alice')).toBe('alice');
+    });
+
+    it('returns the string unchanged when there is no @', () => {
+        expect(stripAt('alice')).toBe('alice');
+    });
+
+    it('only strips one leading @', () => {
+        expect(stripAt('@@alice')).toBe('@alice');
+    });
+
+    it('handles empty input', () => {
+        expect(stripAt('')).toBe('');
+    });
+});

--- a/tests/util/concurrency.test.ts
+++ b/tests/util/concurrency.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+
+import { mapWithConcurrency } from '../../src/util/concurrency';
+
+describe('mapWithConcurrency', () => {
+    it('returns [] for an empty input list', async () => {
+        const fn = async (n: number) => n * 2;
+        await expect(mapWithConcurrency([], 5, fn)).resolves.toEqual([]);
+    });
+
+    it('preserves input order in the result regardless of completion order', async () => {
+        const items = [30, 10, 20];
+        const result = await mapWithConcurrency(items, 3, async (ms) => {
+            await new Promise((r) => setTimeout(r, ms));
+            return ms;
+        });
+        expect(result.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([30, 10, 20]);
+    });
+
+    it('caps simultaneous in-flight calls to the limit', async () => {
+        let inFlight = 0;
+        let peak = 0;
+        const items = Array.from({ length: 10 }, (_, i) => i);
+
+        await mapWithConcurrency(items, 3, async () => {
+            inFlight++;
+            peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 5));
+            inFlight--;
+        });
+
+        expect(peak).toBeLessThanOrEqual(3);
+        expect(peak).toBeGreaterThan(1); // confirms it actually parallelizes
+    });
+
+    it('isolates rejections per item — others still resolve', async () => {
+        const result = await mapWithConcurrency([1, 2, 3], 2, async (n) => {
+            if (n === 2) throw new Error(`fail-${n}`);
+            return n * 10;
+        });
+
+        expect(result[0]).toEqual({ status: 'fulfilled', value: 10 });
+        expect(result[1]?.status).toBe('rejected');
+        expect((result[1] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+        expect(result[2]).toEqual({ status: 'fulfilled', value: 30 });
+    });
+
+    it('uses items.length workers when limit > items.length', async () => {
+        let peak = 0;
+        let inFlight = 0;
+
+        await mapWithConcurrency([1, 2], 100, async () => {
+            inFlight++;
+            peak = Math.max(peak, inFlight);
+            await new Promise((r) => setTimeout(r, 5));
+            inFlight--;
+        });
+
+        expect(peak).toBe(2);
+    });
+});

--- a/tests/util/stream.test.ts
+++ b/tests/util/stream.test.ts
@@ -1,0 +1,32 @@
+import { Readable } from 'node:stream';
+import { describe, it, expect } from 'vitest';
+import { sdkStreamMixin } from '@smithy/util-stream';
+
+import { readJson } from '../../src/util/stream';
+import { ServiceError } from '../../src/errors';
+
+function bodyOf(text: string) {
+    const stream = new Readable();
+    stream.push(text);
+    stream.push(null);
+    return sdkStreamMixin(stream);
+}
+
+describe('readJson', () => {
+    it('parses a JSON body into the typed object', async () => {
+        const body = bodyOf(JSON.stringify({ dutyCount: 3, lastDuty: ['@a'] }));
+        await expect(readJson<{ dutyCount: number; lastDuty: string[] }>(body))
+            .resolves.toEqual({ dutyCount: 3, lastDuty: ['@a'] });
+    });
+
+    it('throws ServiceError when body is undefined', async () => {
+        await expect(readJson(undefined)).rejects.toBeInstanceOf(ServiceError);
+        await expect(readJson(undefined)).rejects.toThrow(/Пустое тело/);
+    });
+
+    it('throws ServiceError on invalid JSON', async () => {
+        const body = bodyOf('not json');
+        await expect(readJson(body)).rejects.toBeInstanceOf(ServiceError);
+        await expect(readJson(bodyOf('also not json'))).rejects.toThrow(/парсинге JSON/);
+    });
+});


### PR DESCRIPTION
## Summary
- Расширяет тестовое покрытие с 14 до 64 тестов, без изменений в проде
- Service: `getChats` (парсинг ключей `trigger/{type}@{id}`, мусор, ошибка S3), `triggerOn/Off`, `init` (exists / PutObject error / non-404 Head), `clear` (включая поглощение ошибки `triggerOff`), `reset`, `duty` (round complete без записи / `dutyCount > users` / пустой список), `list` (фильтрация + ошибки)
- Util: `parseCommandArgs`, `stripAt`, `mapWithConcurrency` (порядок, лимит, изоляция rejection), `readJson`
- Controller: `formatError`, `pt`, `trigger()` (нет чатов / 1 и >1 дежурных / пустой `duty` / падение `getChats` → owner / падение `duty` для одного чата не валит остальные)

Команды Telegraf (`/reg`, `/add`, `/list`, …) через `handleUpdate` сознательно не покрываю — это бы тестировало в основном Telegraf; бизнес-логика этих команд уже покрыта на уровне Service.

## Test plan
- [x] `npm test` — 64/64 passed
- [x] `npm run check` — clean
- [x] `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)