### PR TITLE
ci: bump actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Summary
- GitHub помечает `actions/checkout@v4` и `actions/setup-node@v4` как Node 20 (deprecation в сентябре 2026), v5 у обоих уже на Node 24
- `yc-actions/yc-sls-function@v3` остаётся как есть — миграция на v4 отдельным PR (см. CLAUDE.md)

## Test plan
- [ ] CI на этом PR должен пройти на новых версиях actions
- [ ] После мержа — прогнать deploy и проверить, что warning про Node 20 исчез у наших шагов (yc-sls-function продолжит варнить, это ожидаемо)

🤖 Generated with [Claude Code](https://claude.com/claude-code)