### PR TITLE
ci: bump yc-actions/yc-sls-function v3 → v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Deploy function version
-        uses: yc-actions/yc-sls-function@v3
+        uses: yc-actions/yc-sls-function@v4
         with:
           yc-sa-json-credentials: ${{ secrets.YC_SA_JSON_CREDENTIALS }}
           folder-id: b1givfkfh806tp641l6l

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 GitHub Actions (`.github/workflows/`):
 - `ci.yml` — на `pull_request` в `master`: `npm ci`, `npm run check`, `npm run lint`, `npm test`, `npm run build`.
-- `deploy.yml` — `workflow_dispatch` с input-ом `ref` (ветка/тег/SHA). Делает `npm ci` (с devDeps — нужен esbuild), `npm run build`, затем `yc-actions/yc-sls-function@v3` упаковывает только `dist/**` + `package.json` и создаёт новую версию функции `duty-group-bot` в фолдере `b1givfkfh806tp641l6l`. Тэг `$latest` автоматически переезжает на свежую версию, существующий cron-триггер сразу подхватывает новый код.
-- Action закреплён на `@v3` сознательно; миграцию на `@v4` делать отдельным PR.
+- `deploy.yml` — `workflow_dispatch` с input-ом `ref` (ветка/тег/SHA). Делает `npm ci` (с devDeps — нужен esbuild), `npm run build`, затем `yc-actions/yc-sls-function@v4` упаковывает только `dist/**` + `package.json` и создаёт новую версию функции `duty-group-bot` в фолдере `b1givfkfh806tp641l6l`. Тэг `$latest` автоматически переезжает на свежую версию, существующий cron-триггер сразу подхватывает новый код.
+- Action на `@v4` (yc-sls-function v4 = миграция на yc-sdk 3.x; inputs полностью совместимы с v3). Сам action ещё запускается на `node20` — warning про Node 20 deprecation от GitHub неустраним до релиза upstream с `node24`.
 
 Секреты, которые должны быть в репозитории GitHub:
 - `YC_SA_JSON_CREDENTIALS` — JSON-ключ сервисного аккаунта-деплойера (роли `functions.editor` на фолдер + `iam.serviceAccounts.user` на runtime-SA `ajerdikcv0fdb1s370uf`).


### PR DESCRIPTION
## Summary

- `yc-actions/yc-sls-function@v3` → `@v4` в `deploy.yml`.
- v4.0.0 = внутренняя миграция на `yc-sdk 3.0.0-beta.1`. Сверил `action.yml` v3.3.0 vs v4.1.0 — все наши inputs совместимы (новый `mounts` опциональный, не используем).
- CLAUDE.md обновлён: убран комментарий «миграцию на v4 делать отдельным PR», добавлена явная заметка про оставшийся upstream-warning о Node 20.

## Что НЕ чинит этот PR

GitHub annotation `Node.js 20 actions are deprecated` останется. Сам action всё ещё `using: node20` (даже в v4.1.0). Уйдёт только после релиза upstream с `node24`. Хак `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` не ставлю — он сам станет deprecated после июня 2026.

## Test plan

- [ ] CI green
- [ ] После merge — `workflow_dispatch deploy.yml` на master, проверить:
  - [ ] деплой успешен
  - [ ] логи без новых предупреждений (кроме известного Node 20)
  - [ ] функция `duty-group-bot` получила новую версию

🤖 Generated with [Claude Code](https://claude.com/claude-code)